### PR TITLE
Add jsdelivr as optional link with rawgit

### DIFF
--- a/webpage/index.html
+++ b/webpage/index.html
@@ -225,7 +225,13 @@ You can turn your favorite frog CI tool into a handsome prince in few steps! Ins
 <img src="https://jenkins-themes.alefnode.com/images/pallete.png" alt="image" /></p>
   </li>
   <li>
-    <p>Replace `{{your-color-name}}` in the URL by the chosen color: <code class="highlighter-rouge">https://ghcdn.rawgit.org/alefnode/jenkins-themes/CDN/dist/material-{{your-color-name}}.css</code></p>
+    <p>
+      Replace `{{your-color-name}}` in the URL by the chosen color: 
+      <br>
+      <code class="highlighter-rouge">https://ghcdn.rawgit.org/alefnode/jenkins-themes/CDN/dist/material-{{your-color-name}}.css</code>
+      <br>
+      <code class="highlighter-rouge">https://cdn.jsdelivr.net/gh/alefnode/jenkins-themes@CDN/dist/material-{{your-color-name}}.css</code>
+    </p>
   </li>
   <li>
     <p>Click <code class="highlighter-rouge">Manage Jenkins</code></p>


### PR DESCRIPTION
As said here adding new links in webpage to inform users about other posibilities rather than rawgit

https://github.com/alefnode/jenkins-themes/issues/13